### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,7 @@
 <p>Tired of typing in every single airport identifier code before you brief? Enjoy these links</p>
 <p></p>
 <p><b>DD-175-1 Wx Brief</b></p>
-<a href="https://fwb.metoc.navy.mil/fwb18" target="_blank" rel="noopener noreferrer">METOC Server</a>
-<p></p>
-<a href="https://fwb.navo.navy.mil/fwb18" target="_blank" rel="noopener noreferrer">NAVO Server</a>
+<a href="https://fwb.metoc.navy.mil" target="_blank" rel="noopener noreferrer">METOC Server</a>
 <p></p>
 <p> </p>
 <p><b>NOTAMS</b></p> <!-- KNGP+KCRP+KTFP+KALI+KNOG+KIKG+KVCT+KPSX+KPIL+KBRO+KHRL+KMFE+KZHU+KGPS  -->
@@ -38,19 +36,13 @@ target="_blank" rel="noopener noreferrer">
 
 <p></p>
 <p><b>BASH Report</b></p>
-<a href="https://www.usahas.com/AHASMap.html?Area=VT-31" target="_blank" rel="noopener noreferrer">VT-31 BASH Area</a>
+<a href="https://www.usahas.com" target="_blank" rel="noopener noreferrer">BASH Home</a>
 <p></p>
 <p></p>
 
-<p><b>METARS and TAFs (If first one doesn't work, use second)</b></p>
-<a href="https://www.aviationweather.gov/metar/data?ids=
-   KNGP+KCRP+KTFP+KALI+KNOG+KNQI+KIKG+KVCT+KPSX+KPIL+KBRO+KHRL+KMFE&format=raw&date=0&hours=0&taf=on" 
+<p><b>METARS and TAF</b></p>
+<a href="https://aviationweather.gov/data/metar/?id=KNGP,KCRP,KTFP,KALI,KNOG,KNQI,KIKG,KVCT,KPSX,KPIL,KBRO,KHRL,KMFE&hours=0&include_taf=yes" 
    target="_blank" rel="noopener noreferrer">aviationweather.gov</a>
-<p></p>
-<a href="https://bcaws.aviationweather.gov/metar/data?ids=
-KNGP+KCRP+KTFP+KALI+KNOG+KNQI+KIKG+KVCT+KPSX+KPIL+KBRO+KHRL+KMFE&format=raw&date=&hours=0&taf=on" 
-target="_blank" rel="noopener noreferrer">bcaws.viationweather.gov</a>
-
 <p></p>
 <p></p>
 
@@ -77,6 +69,7 @@ target="_blank" rel="noopener noreferrer">bcaws.viationweather.gov</a>
 <p>Changelog</p>
 <p>18 March 20: Added RAIM, skyvector, KNQI and KNGW to links</p>
 <p>25 March 20: Added OPARS and BASEOPS links</p>
+<p>21 October 23: Updated links for METARs/TAFs, BASH, and FWB</p>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <body>
 <img src="images/T44.jpg" alt="The mighty T-44C Pegasus" height="325" width="605">
 
-<h1>What's up my Stingrays</h1>
+<h1>What's up Stingrays</h1>
 <p>Tired of typing in every single airport identifier code before you brief? Enjoy these links</p>
 <p></p>
 <p><b>DD-175-1 Wx Brief</b></p>


### PR DESCRIPTION
Updated links for METARs, TAFs, BASH, and FWB. Aviation weather went through an update and now uses "," as separators for ICAO, instead of "+". FWB has a new link that no longer includes "/18" and BASH no longer resolves to a separate website when preferences are selected so I just changed the link to the BASH homepage.